### PR TITLE
แก้บัคศูนย์สตางค์สะกดออกมาเป็นบาทสตางค์

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "in.norbor"
 
 name := "yoda-bahttext"
 
-version := "1.0b"
+version := "1.0.1"
 
 crossPaths := false
 

--- a/src/main/java/in/norbor/yoda/BahtText.java
+++ b/src/main/java/in/norbor/yoda/BahtText.java
@@ -3,20 +3,21 @@ package in.norbor.yoda;
 import java.util.StringTokenizer;
 
 /**
- *  @author Peerapat A, Sep 26, 2017
+ * @author Peerapat A, Sep 26, 2017
  */
 public abstract class BahtText {
 
     private static final String[] TXT_NUM = {"ศูนย์", "หนึ่ง", "สอง", "สาม", "สี่", "ห้า", "หก", "เจ็ด", "แปด", "เก้า"};
     private static final String[] TXT_WEIGHT = {"", "สิบ", "ร้อย", "พัน", "หมื่น", "แสน"};
-    private static final String TXT_ZEROBAHT = "ศูนย์บาท";
+    private static final String TXT_ZERO_BAHT = "ศูนย์บาท";
 
-    private BahtText() {}
+    private BahtText() {
+    }
 
     /**
      * final String amount = BahtText.toText(100.00);
      *
-     * @param  currency 100
+     * @param currency 100
      * @return String หนึ่งร้อยบาทถ้วน
      */
     public static String toText(final double currency) {
@@ -29,8 +30,7 @@ public abstract class BahtText {
      * @param currency 100
      * @return String หนึ่งร้อยบาทถ้วน
      */
-    public static String toText(final String currency)
-            throws NumberFormatException {
+    public static String toText(final String currency) throws NumberFormatException {
         String number = currency;
 
         throwIfNull(number);
@@ -41,7 +41,7 @@ public abstract class BahtText {
         final StringPair pair = tokenizeStringWithDot(number);
 
         if (isStringNumberCompleteZero(pair)) {
-            return TXT_ZEROBAHT;
+            return TXT_ZERO_BAHT;
         }
         return generateResultString(pair);
     }
@@ -87,13 +87,11 @@ public abstract class BahtText {
     }
 
 
-
     private static boolean isStringNumberCompleteZero(final StringPair pair) {
         final boolean beforeDotIsZero = isZero(pair.before); // ดูว่าหน้าทศนิยมเป็น 0 หรือไม่
         final boolean afterDotIsZero = (pair.after == null) || isZero(pair.after);
 
         return beforeDotIsZero && afterDotIsZero;
-
     }
 
     private static StringPair tokenizeStringWithDot(final String number) {
@@ -102,7 +100,7 @@ public abstract class BahtText {
         final String beforeDot = st.nextToken();
         final String afterDot = (st.hasMoreTokens()) ? st.nextToken() : null; // ทศนิยม
 
-        return new StringPair(beforeDot,afterDot);
+        return new StringPair(beforeDot, afterDot);
     }
 
     private static String generateResultString(final StringPair pair) {
@@ -135,7 +133,7 @@ public abstract class BahtText {
                 result.append(generateWordNumber(afterDotArr1));
             }
 
-            if (afterDot.equals("00")) {
+            if (Integer.parseInt(afterDot) == 0) {
                 result.append("ถ้วน");
             } else {
                 result.append("สตางค์");
@@ -185,7 +183,7 @@ public abstract class BahtText {
                 } else if (i == (length - 2) && ch == '2') {
                     result.append("ยี่"); // ดักเลข 20 -> ยี่สิบ
                 } else if (i == (length - 2) && ch == '1') {
-                    result.append(""); // ดักเลข 10 -> สิบ ไม่ใช่ หนึ่งสิบ
+                    result.substring(0); // ดักเลข 10 -> สิบ ไม่ใช่ หนึ่งสิบ
                 } else {
                     result.append(TXT_NUM[((int) ch) - 48]);
                 }

--- a/src/test/java/in/norbor/yoda/BahtTextTest.java
+++ b/src/test/java/in/norbor/yoda/BahtTextTest.java
@@ -2,8 +2,10 @@ package in.norbor.yoda;
 
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 /**
- *  @author Peerapat A, Sep 26, 2017
+ * @author Peerapat A, Sep 26, 2017
  */
 public class BahtTextTest {
 
@@ -16,9 +18,9 @@ public class BahtTextTest {
         final String resultFromString = BahtText.toText(inputString);
         final String resultFromDouble = BahtText.toText(inputDouble);
 
-        assert expResult.equals(resultFromDouble);
-        assert resultFromDouble.equals(resultFromString);
-        assert expResult.equals(resultFromString);
+        assertEquals(expResult, resultFromDouble);
+        assertEquals(expResult, resultFromString);
+        assertEquals(resultFromDouble, resultFromString);
     }
 
     @Test
@@ -26,31 +28,31 @@ public class BahtTextTest {
         final String expResult = "ศูนย์บาท";
         final String result = BahtText.toText("0");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
     }
 
     @Test
     public void แปลงค่าหนึ่งบาท() {
-        final String expResult = "หนึ่งบาท";
+        final String expResult = "หนึ่งบาทถ้วน";
         final String result = BahtText.toText("1");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
     }
 
     @Test
     public void แปลงค่าสิบบาท() {
-        final String expResult = "สิบบาท";
+        final String expResult = "สิบบาทถ้วน";
         final String result = BahtText.toText("10");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
     }
 
     @Test
     public void แปลงค่ายี่สิบเอ็ดบาท() {
-        final String expResult = "ยี่สิบเอ็ดบาท";
+        final String expResult = "ยี่สิบเอ็ดบาทถ้วน";
         final String result = BahtText.toText("21");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
     }
 
     @Test
@@ -58,7 +60,7 @@ public class BahtTextTest {
         final String expResult = "หนึ่งหมื่นสองพันสองร้อยหนึ่งล้านห้าแสนแปดหมื่นสี่พันเจ็ดร้อยหกสิบเอ็ดบาทสามสิบเก้าสตางค์";
         final String result = BahtText.toText("12,201,584,761.39");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
     }
 
     @Test
@@ -66,15 +68,15 @@ public class BahtTextTest {
         final String expResult = "หนึ่งร้อยบาทยี่สิบห้าสตางค์";
         final String result = BahtText.toText("100.25");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
     }
 
     @Test
     public void แปลงค่าหนึ่งล้านบาท() {
-        final String expResult = "หนึ่งล้านบาท";
+        final String expResult = "หนึ่งล้านบาทถ้วน";
         final String result = BahtText.toText("1,000,000");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
     }
 
     @Test
@@ -82,7 +84,7 @@ public class BahtTextTest {
         final String expResult = "หนึ่งร้อยบาทสิบสองสตางค์";
         final String result = BahtText.toText("100.125");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
     }
 
     @Test
@@ -90,7 +92,7 @@ public class BahtTextTest {
         final String expResult = "หนึ่งร้อยบาทสิบสตางค์";
         final String result = BahtText.toText("100.1");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
     }
 
     @Test
@@ -98,15 +100,31 @@ public class BahtTextTest {
         final String expResult = "ศูนย์บาท";
         final String result = BahtText.toText(".");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
     }
 
     @Test
     public void ล้านล้านบาท() {
-        final String expResult = "หนึ่งล้านล้านบาท";
+        final String expResult = "หนึ่งล้านล้านบาทถ้วน";
         final String result = BahtText.toText("1,000,000,000,000");
 
-        assert result.equals(expResult);
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void ทศนิยม00ควรจะไม่แสดงคำว่าสตางค์() {
+        final String expResult = "หนึ่งล้านบาทถ้วน";
+        final String result = BahtText.toText("1,000,000.00");
+
+        assertEquals(expResult, result);
+    }
+
+    @Test
+    public void ทศนิยม0ควรจะไม่แสดงคำว่าสตางค์() {
+        final String expResult = "หนึ่งล้านบาทถ้วน";
+        final String result = BahtText.toText(1000000.00);
+
+        assertEquals(expResult, result);
     }
 
 }


### PR DESCRIPTION
บัค 0 สตางค์​ อ่านออกมาเป็น `บาทสตางค์` แก้ให้เป็น `บาทถ้วน`